### PR TITLE
cmake: allow external capstone, zydis, and asmjit libraries to be use…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ option(POLYHOOK_BUILD_SHARED_ASMJIT "Build polyhook as shared libary" OFF)
 option(POLYHOOK_BUILD_SHARED_CAPSTONE "Build capstone as shared libary" OFF)
 option(POLYHOOK_BUILD_SHARED_ZYDIS "Build polyhook as shared libary" OFF)
 
+option(POLYHOOK_USE_EXTERNAL_ASMJIT "Use external asmjit libary" OFF)
+option(POLYHOOK_USE_EXTERNAL_CAPSTONE "Use external capstone libary" OFF)
+option(POLYHOOK_USE_EXTERNAL_ZYDIS "Use external zydis libary" OFF)
+
 if(MSVC)
 	option(POLYHOOK_BUILD_STATIC_RUNTIME "Use static runtime" ON)
 endif()
@@ -38,7 +42,7 @@ endif()
 # ASMJIT
 #
 
-if(POLYHOOK_FEATURE_INLINENTD)
+if(POLYHOOK_FEATURE_INLINENTD AND NOT POLYHOOK_USE_EXTERNAL_ASMJIT)
 
 	if(POLYHOOK_BUILD_SHARED_ASMJIT)
 		set(ASMJIT_STATIC OFF CACHE BOOL "")
@@ -60,7 +64,7 @@ endif()
 # Capstone
 #
 
-if(POLYHOOK_DISASM_CAPSTONE)
+if(POLYHOOK_DISASM_CAPSTONE AND NOT POLYHOOK_USE_EXTERNAL_CAPSTONE)
 	set(CAPSTONE_BUILD_STATIC_RUNTIME ${POLYHOOK_BUILD_STATIC_RUNTIME} CACHE BOOL "")
 	if(POLYHOOK_BUILD_SHARED_CAPSTONE)
 		set(CAPSTONE_BUILD_SHARED ON CACHE BOOL "")
@@ -106,7 +110,7 @@ endif()
 # Zydis
 #
 
-if(POLYHOOK_DISASM_ZYDIS)
+if(POLYHOOK_DISASM_ZYDIS AND NOT POLYHOOK_USE_EXTERNAL_ZYDIS)
     set(ZYDIS_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "")
 	set(ZYCORE_BUILD_SHARED_LIB ${POLYHOOK_BUILD_SHARED_ZYDIS} CACHE BOOL "")
 	set(ZYDIS_BUILD_TOOLS OFF CACHE BOOL "")
@@ -190,26 +194,39 @@ target_sources(${PROJECT_NAME} PRIVATE
 
 #DisAsm/Capstone
 if(POLYHOOK_DISASM_CAPSTONE)
-	target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CAPSTONE_LIBRARY_NAME}>)
-	install(TARGETS ${CAPSTONE_LIBRARY_NAME} EXPORT exporthack)
-
+	if (POLYHOOK_USE_EXTERNAL_CAPSTONE)
+		find_library(CAPSTONE_LIBRARY NAMES capstone_dll capstone)
+		find_path(CAPSTONE_INCLUDE_DIR NAMES capstone/capstone.h)
+		target_link_libraries(${PROJECT_NAME} PRIVATE ${CAPSTONE_LIBRARY})
+		target_include_directories(${PROJECT_NAME} PRIVATE ${CAPSTONE_INCLUDE_DIR})
+	else()
+		target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CAPSTONE_LIBRARY_NAME}>)
+		target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/capstone/include>)
+		install(TARGETS ${CAPSTONE_LIBRARY_NAME} EXPORT exporthack)
+	endif()
 	target_sources(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/sources/CapstoneDisassembler.cpp")
-
-	target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/capstone/include>)
-
 	install(FILES ${PROJECT_SOURCE_DIR}/polyhook2/CapstoneDisassembler.hpp DESTINATION include/polyhook2)
 endif()
 
 #DisAsm/Zydis
 if(POLYHOOK_DISASM_ZYDIS)
-	target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:Zydis>)
-
-	target_sources(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/sources/ZydisDisassembler.cpp")
-
-	target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/zydis/include>)
-	target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/zydis/dependencies/zycore/include>)
-	target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/zydis>)
+	if (POLYHOOK_USE_EXTERNAL_ZYDIS)
+		find_library(ZYDIS_LIBRARY NAMES zydis)
+		find_library(ZYCORE_LIBRARY NAMES zycore)
+		find_path(ZYDIS_INCLUDE_DIR NAMES zydis/zydis.h)
+		find_path(ZYCORE_INCLUDE_DIR NAMES zycore/zycore.h)
+		target_link_libraries(${PROJECT_NAME} PRIVATE ${ZYDIS_LIBRARY})
+		target_link_libraries(${PROJECT_NAME} PRIVATE ${ZYCORE_LIBRARY})
+		target_include_directories(${PROJECT_NAME} PRIVATE ${ZYDIS_INCLUDE_DIR})
+		target_include_directories(${PROJECT_NAME} PRIVATE ${ZYCORE_INCLUDE_DIR})
+	else()
+		target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:Zydis>)
+		target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/zydis/include>)
+		target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/zydis/dependencies/zycore/include>)
+		target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/zydis>)
+	endif()
 	
+	target_sources(${PROJECT_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/sources/ZydisDisassembler.cpp")
 	install(FILES ${PROJECT_SOURCE_DIR}/polyhook2/ZydisDisassembler.hpp DESTINATION include/polyhook2)
 endif()
 
@@ -260,7 +277,14 @@ endif()
 
 #Feature/Inlinentd
 if(POLYHOOK_FEATURE_INLINENTD)
-	target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:asmjit>)
+	if (POLYHOOK_USE_EXTERNAL_ASMJIT)
+		find_library(ASMJIT_LIBRARY NAMES asmjit)
+		find_path(ASMJIT_INCLUDE_DIR NAMES asmjit/asmjit.h)
+		target_link_libraries(${PROJECT_NAME} PRIVATE ${ASMJIT_LIBRARY})
+		target_include_directories(${PROJECT_NAME} PRIVATE ${ASMJIT_INCLUDE_DIR})
+	else()
+		target_link_libraries(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:asmjit>)
+	endif()
 
 	install(FILES ${PROJECT_SOURCE_DIR}/polyhook2/Detour/ILCallback.hpp DESTINATION include/polyhook2/Detour)
 


### PR DESCRIPTION
…d, instead of the bundled ones. (#63)